### PR TITLE
Delete temporary files in AudioSegment.export() (#665)

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -966,19 +966,20 @@ class AudioSegment(object):
         log_subprocess_output(p_out)
         log_subprocess_output(p_err)
 
-        if p.returncode != 0:
-            raise CouldntEncodeError(
-                "Encoding failed. ffmpeg/avlib returned error code: {0}\n\nCommand:{1}\n\nOutput from ffmpeg/avlib:\n\n{2}".format(
-                    p.returncode, conversion_command, p_err.decode(errors='ignore') ))
+        try:
+            if p.returncode != 0:
+                raise CouldntEncodeError(
+                    "Encoding failed. ffmpeg/avlib returned error code: {0}\n\nCommand:{1}\n\nOutput from ffmpeg/avlib:\n\n{2}".format(
+                        p.returncode, conversion_command, p_err.decode(errors='ignore') ))
 
-        output.seek(0)
-        out_f.write(output.read())
+            output.seek(0)
+            out_f.write(output.read())
 
-        data.close()
-        output.close()
-
-        os.unlink(data.name)
-        os.unlink(output.name)
+        finally:
+            data.close()
+            output.close()
+            os.unlink(data.name)
+            os.unlink(output.name)
 
         out_f.seek(0)
         return out_f


### PR DESCRIPTION
* Delete temporary files even when export() AudioSegment.export() has an error

* refactor: clean up temp files with a finally block

This is a cleaner solution where we don't need to repeat the clean up code, since the finally block executes in all cases.